### PR TITLE
Dismantling of the flagpole

### DIFF
--- a/BasicTerritories/scripts/3_Game/BasicTerritoriesConfig.c
+++ b/BasicTerritories/scripts/3_Game/BasicTerritoriesConfig.c
@@ -34,6 +34,7 @@ class BasicTerritoriesConfig
 	string DeSpawnWarningMessage = " You are building outside a territory, $ITEMNAME$ will despawn in $LIFETIME$ without a Territory";
 	string BuildPartWarningMessage = " Sorry, you don't have permissions to build in this area.";
 	string DismantleWarningMessage = " Sorry, you can't dismantle anything this close to a raised flag";
+	string DismantleFlagpoleWarningMessage = " Sorry, you can't dismantle this flagpole";
 	string LowerFlagWarningMessage = " Sorry, you do not have permissions to lower the flag in this territory";
 	string TerritoryRequiredWarningMessage = " Sorry, you are required to build a territory to be able to build";
 	

--- a/BasicTerritories/scripts/4_World/Actions/ActionDismantlePart.c
+++ b/BasicTerritories/scripts/4_World/Actions/ActionDismantlePart.c
@@ -2,13 +2,29 @@ modded class ActionDismantlePart : ActionContinuousBase
 {
 	override bool ActionCondition( PlayerBase player, ActionTarget target, ItemBase item )
 	{	
-		ItemBase theTarget;
 		if (super.ActionCondition( player, target, item )){
 			if (GetGame().IsServer()){
 				return true;
 			}
+
+			TerritoryFlag theFlag = TerritoryFlag.Cast( target.GetObject() );
+			PlayerBase thePlayer = PlayerBase.Cast(player);
+
+			if ( theFlag && thePlayer && thePlayer.GetIdentity() ){
+				theFlag.SyncTerritoryRateLimited();
+				if (vector.Distance(theFlag.GetPosition(), thePlayer.GetPosition()) > UAMisc.MAX_DISTANCE_FROM_FLAG){
+					return false;
+				}
+				if (!theFlag.CheckPlayerPermission(thePlayer.GetIdentity().GetId(), TerritoryPerm.DISMANTLE)){
+					GetBasicTerritoriesConfig().SendNotification(GetBasicTerritoriesConfig().DismantleFlagpoleWarningMessage, TerritoryIcons.DismantleWarning);
+					return false;
+				}
+				return true;
+			}
+
+			ItemBase theTarget;
+
 			if ( Class.CastTo( theTarget, target.GetObject() ) || Class.CastTo( theTarget, target.GetParent()) ) {
-				PlayerBase thePlayer = PlayerBase.Cast(player);
 				if (theTarget && thePlayer) {
 					string theGUID = "";
 					if ( thePlayer.GetIdentity() ) {
@@ -19,8 +35,8 @@ modded class ActionDismantlePart : ActionContinuousBase
 						return false;
 					}
 				}
+				return true;
 			}
-			return true;
 		}
 		return false;
 	}

--- a/BasicTerritories/scripts/4_World/TerritoryFlag.c
+++ b/BasicTerritories/scripts/4_World/TerritoryFlag.c
@@ -299,11 +299,11 @@ modded class TerritoryFlag extends BaseBuildingBase
 		if (guid == m_TerritoryOwner){ //Is Owner
 			return true;
 		}
-		
-		if (HasRaisedFlag()){
-			return m_TerritoryMembers.Check(guid, permission); //Is member or not
-		}
-		return true;
+
+        if (!m_TerritoryOwner)
+            return true;
+
+        return m_TerritoryMembers.Check(guid, permission); //Is member or not
 	}
 	
 	


### PR DESCRIPTION
Before, when the flag was fully lowered, anyone could dismantle the flagpole, even when the territory was still claimed. Now, dismantling of the flagpole is only possible when registered on the flagpole as owner or member, or if flagpole is unclaimed.

Before, when the flag was fully lowered, CheckPlayerPermission actually always returned true, even if the territory was still claimed. This is no longer the case.